### PR TITLE
fixes "invalid closing tag name" message

### DIFF
--- a/dm_test/factions/dark_magic/units/shade/particle_ball.xml
+++ b/dm_test/factions/dark_magic/units/shade/particle_ball.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="yes"?>
-<unit-particle-system>
+<projectile-particle-system>
     	<texture value="true" path="images/particle.bmp" luminance="true"/>
 	<mode value="black"/>
     	<model value="false"/>
@@ -14,7 +14,6 @@
     	<emission-rate value="3" />
     	<energy-max value="40" />
     	<energy-var value="0" />
-	
 	<trajectory type="spiral">
 		<speed value="14.0"/>
 		<scale value="0.4"/>


### PR DESCRIPTION
Prior to the fix, dm_test worked on 3.12, but caused MG git
to crash. Now works on git.