### PR TITLE
add support for multi-building select

### DIFF
--- a/dm_test/factions/dark_magic/units/blood_fountain/blood_fountain.xml
+++ b/dm_test/factions/dark_magic/units/blood_fountain/blood_fountain.xml
@@ -6,10 +6,10 @@
 		<max-hp value="1400" regeneration="0"/>
 		<max-ep value="0"/>
 		<armor value="0" />
-		<armor-type value="stone"/>				
+		<armor-type value="stone"/>
 		<sight value="5" />
 		<time value="50" />
-		<multi-selection value="false" />
+		<multi-selection value="true" />
 		<cellmap value="false"/>
 		<levels/>
 		<fields>
@@ -28,7 +28,7 @@
 			<resource name="stone" amount="100"/>
 		</resource-requirements>
 		<resources-stored>
-			<resource name= "gold" amount="100"/>				
+			<resource name= "gold" amount="100"/>
 		</resources-stored>
 		<image path="images/energy_fountain.bmp"/>
 		<image-cancel path="../dark_elder/images/dark_magic_cancel.bmp"/>
@@ -40,11 +40,11 @@
 			<sound path="../enchantment_tower/sounds/dark_magic_click.wav"/>
 		</command-sounds>
 	</parameters>
-	
+
 	<skills>
 		<skill>
 			<type value="be_built" />
-			<name value="be_built_skill"/>		
+			<name value="be_built_skill"/>
 			<ep-cost value="0" />
 			<speed value="120"/>
 			<speed value="120"/>
@@ -52,10 +52,10 @@
 			<animation path="models/construction_blood_fountain.g3d" />
 			<sound enabled="false" />
 		</skill>
-		
+
 		<skill>
 			<type value="stop" />
-			<name value="stop_skill"/>		
+			<name value="stop_skill"/>
 			<ep-cost value="0" />
 			<speed value="300" />
 			<anim-speed value="100" />
@@ -69,7 +69,7 @@
 
 		<skill>
 			<type value="produce"/>
-			<name value="produce_skill"/>		
+			<name value="produce_skill"/>
 			<ep-cost value="0"/>
 			<speed value="150"/>
 			<anim-speed value="80"/>
@@ -79,18 +79,18 @@
 				<particle-file path="blood_particles_produce.xml"/>
 			</particles>
 			<sound enabled="false"/>
-		</skill>	
-		
+		</skill>
+
 		<skill>
 			<type value="die" />
-			<name value="die_skill"/>		
+			<name value="die_skill"/>
 			<ep-cost value="0" />
 			<speed value="300" />
 			<anim-speed value="300" />
 			<animation path="models/destruction_blood_fountain.g3d" />
 			<sound enabled="true" start-time="0">
 				<sound-file path="../enchantment_tower/sounds/dark_magic_building_fall1.wav"/>
-			</sound>			
+			</sound>
 			<fade value="false"/>
 		</skill>
 

--- a/dm_test/factions/dark_magic/units/cursed_grave/cursed_grave.xml
+++ b/dm_test/factions/dark_magic/units/cursed_grave/cursed_grave.xml
@@ -6,18 +6,18 @@
 		<height value="5"/>
 		<max-hp value="1500" regeneration="10"/>
 		<max-ep value="0"/>
-		<armor value="50"/>	
-		<armor-type value="organic"/>			
+		<armor value="50"/>
+		<armor-type value="organic"/>
 		<sight value="16"/>
-		<time value="140"/>	
-		<multi-selection value="false"/>
+		<time value="140"/>
+		<multi-selection value="true"/>
 		<cellmap value="false"/>
 		<levels>
 			<level name="expert" kills="20"/>
 		</levels>
 		<fields>
 			<field value="land"/>
-		</fields>	
+		</fields>
 		<properties/>
 		<light enabled="false"/>
 		<unit-requirements>
@@ -27,8 +27,8 @@
 			<upgrade name="dark_sorcery"/>
 		</upgrade-requirements>
 		<resource-requirements>
-			<resource name="gold" amount="200"/>	
-			<resource name="souls" amount="3"/>			
+			<resource name="gold" amount="200"/>
+			<resource name="souls" amount="3"/>
 		</resource-requirements>
 		<resources-stored/>
 		<image path="images/earth_serpent.bmp"/>
@@ -43,17 +43,17 @@
 	<skills>
 		<skill>
 			<type value="be_built"/>
-			<name value="be_built_skill"/>		
+			<name value="be_built_skill"/>
 			<ep-cost value="0"/>
 			<speed value="300"/>
 			<anim-speed value="40"/>
 			<animation path="models/gravestone.g3d"/>
 			<sound enabled="false"/>
 		</skill>
-	
+
 		<skill>
 			<type value="stop"/>
-			<name value="stop_skill"/>		
+			<name value="stop_skill"/>
 			<ep-cost value="0"/>
 			<speed value="300"/>
 			<anim-speed value="50"/>
@@ -63,7 +63,7 @@
 
 		<skill>
 			<type value="attack"/>
-			<name value="attack_skill"/>		
+			<name value="attack_skill"/>
 			<ep-cost value="0"/>
 			<speed value="75"/>
 			<anim-speed value="60"/>
@@ -96,7 +96,7 @@
 
 		<skill>
 			<type value="move"/>
-			<name value="move_skill"/>		
+			<name value="move_skill"/>
 			<ep-cost value="1"/>
 			<speed value="1"/>
 			<anim-speed value="10"/>
@@ -106,18 +106,18 @@
 
 		<skill>
 			<type value="die"/>
-			<name value="die_skill"/>		
+			<name value="die_skill"/>
 			<ep-cost value="0"/>
 			<speed value="300"/>
 			<anim-speed value="300"/>
 			<animation path="models/gravestone_destruction.g3d"/>
 			<sound enabled="true" start-time="0">
 				<sound-file path="../enchantment_tower/sounds/dark_magic_building_fall5.wav"/>
-			</sound>			
+			</sound>
 			<fade value="false"/>
 		</skill>
 	</skills>
-	
+
 	<commands>
 		<command>
 			<type value="stop"/>
@@ -127,7 +127,7 @@
 			<upgrade-requirements/>
 			<stop-skill value="stop_skill"/>
 		</command>
-		
+
 		<command>
 			<type value="attack"/>
 			<name value="attack"/>

--- a/dm_test/factions/dark_magic/units/divination_crystal/divination_crystal.xml
+++ b/dm_test/factions/dark_magic/units/divination_crystal/divination_crystal.xml
@@ -6,10 +6,10 @@
 		<max-hp value="6000" regeneration="0"/>
 		<max-ep value="0" />
 		<armor value="0" />
-		<armor-type value="stone"/>		
+		<armor-type value="stone"/>
 		<sight value="11" />
 		<time value="120" />
-		<multi-selection value="false" />
+		<multi-selection value="true" />
 		<cellmap value="false"/>
 		<levels/>
 		<fields>
@@ -37,10 +37,10 @@
 			<sound path="../enchantment_tower/sounds/dark_magic_click.wav" />
 		</command-sounds>
 	</parameters>
-	
+
 	<skills>
 		<skill>
-			<name value="be_built_skill"/>		
+			<name value="be_built_skill"/>
 			<ep-cost value="0" />
 			<speed value="300" />
 			<anim-speed value="10" />
@@ -48,37 +48,37 @@
 			<sound enabled="false" />
 			<type value="be_built" />
 		</skill>
-		
+
 		<skill>
 			<type value="stop" />
-			<name value="stop_skill"/>		
+			<name value="stop_skill"/>
 			<ep-cost value="0" />
 			<speed value="300" />
 			<anim-speed value="50" />
 			<animation path="models/divination_crystal_idle.g3d" />
 			<sound enabled="false" />
-		</skill>	
-		
+		</skill>
+
 		<skill>
 			<type value="upgrade" />
-			<name value="upgrade_skill"/>		
+			<name value="upgrade_skill"/>
 			<ep-cost value="0" />
 			<speed value="300" />
 			<anim-speed value="75" />
 			<animation path="models/divination_crystal_working.g3d" />
 			<sound enabled="false"/>
 		</skill>
-		
+
 		<skill>
 			<type value="die" />
-			<name value="die_skill"/>		
+			<name value="die_skill"/>
 			<ep-cost value="0" />
 			<speed value="300" />
 			<anim-speed value="300" />
 			<animation path="models/destruction_divination_crystal.g3d" />
 			<sound enabled="true" start-time="0">
 				<sound-file path="../enchantment_tower/sounds/dark_magic_building_fall3.wav"/>
-			</sound>			
+			</sound>
 			<fade value="false"/>
 		</skill>
 	</skills>

--- a/dm_test/factions/dark_magic/units/enchantment_tower/enchantment_tower.xml
+++ b/dm_test/factions/dark_magic/units/enchantment_tower/enchantment_tower.xml
@@ -10,7 +10,7 @@
 		<armor-type value="stone"/>
 		<sight value="16" />
 		<time value="250" />
-		<multi-selection value="false" />
+		<multi-selection value="true" />
 		<cellmap value="false"/>
 		<levels/>
 		<fields>
@@ -55,7 +55,7 @@
 			<animation path="models/pain_tower_construction.g3d" />
 			<sound enabled="false"/>
 		</skill>
-		
+
 		<skill>
 			<type value="stop"/>
 			<name value="stop_skill"/>
@@ -71,14 +71,14 @@
 
 		<skill>
 			<type value="move"/>
-			<name value="move_skill"/>		
+			<name value="move_skill"/>
 			<ep-cost value="0"/>
 			<speed value="0"/>
 			<anim-speed value="0"/>
 			<animation path="models/pain_tower.g3d"/>
 			<sound enabled="false"/>
-		</skill>	
-		
+		</skill>
+
 		<skill>
 			<type value="upgrade"/>
 			<name value="upgrade_skill"/>
@@ -91,17 +91,17 @@
 			</particles>
 			<sound enabled="false"/>
 		</skill>
-		
+
 		<skill>
 			<type value="die"/>
-			<name value="die_skill"/>	
+			<name value="die_skill"/>
 			<ep-cost value="0"/>
 			<speed value="15"/>
 			<anim-speed value="15"/>
 			<animation path="models/pain_tower_destruction.g3d"/>
 			<sound enabled="true" start-time="0">
 				<sound-file path="sounds/dark_magic_building_fall6.wav"/>
-			</sound>			
+			</sound>
 			<fade value="true"/>
 		</skill>
 	</skills>
@@ -117,7 +117,7 @@
 			<upgrade-skill value="upgrade_skill"/>
 			<produced-upgrade name="seething_of_the_blazes"/>
 		</command>
-    
+
     <command>
 			<type value="upgrade"/>
 			<name value="research_magik"/>

--- a/dm_test/factions/dark_magic/units/incantation_shrine/incantation_shrine.xml
+++ b/dm_test/factions/dark_magic/units/incantation_shrine/incantation_shrine.xml
@@ -7,16 +7,16 @@
 		<max-hp value="12000" regeneration="0"/>
 		<max-ep value="0"/>
 		<armor value="0"/>
-		<armor-type value="stone"/>				
+		<armor-type value="stone"/>
 		<sight value="15"/>
 		<time value="250"/>
-		<multi-selection value="false"/>
+		<multi-selection value="true"/>
 		<cellmap value="true">
-			<row value="01010"/> 
-			<row value="11011"/> 
-			<row value="11011"/> 
-			<row value="11011"/> 
-			<row value="01010"/> 
+			<row value="01010"/>
+			<row value="11011"/>
+			<row value="11011"/>
+			<row value="11011"/>
+			<row value="01010"/>
 		</cellmap>
 		<levels/>
 		<fields>
@@ -35,8 +35,8 @@
 		</resource-requirements>
 		<resources-stored>
 			<resource name= "gold" amount="2100"/>
-			<resource name= "wood" amount="1300"/>				
-			<resource name= "stone" amount="1200"/>				
+			<resource name= "wood" amount="1300"/>
+			<resource name= "stone" amount="1200"/>
 		</resources-stored>
 		<image path="images/sheol_temple.bmp" />
 		<image-cancel path="../dark_elder/images/dark_magic_cancel.bmp"/>
@@ -48,13 +48,13 @@
 			<sound path="../enchantment_tower/sounds/dark_magic_click.wav"/>
 		</command-sounds>
 	</parameters>
-	
+
 	<!-- *** skills *** -->
 	<skills>
 
 		<skill>
 			<type value="stop" />
-			<name value="stop_skill"/>		
+			<name value="stop_skill"/>
 			<ep-cost value="0" />
 			<speed value="500" />
 			<anim-speed value="100" />
@@ -62,21 +62,21 @@
 
 			<sound enabled="false" />
 		</skill>
-		
+
 		<skill>
 			<type value="be_built"/>
-			<name value="be_built_skill"/>		
+			<name value="be_built_skill"/>
 			<ep-cost value="0"/>
 			<speed value="300"/>
 			<anim-speed value="3"/>
 			<animation path="models/sheol_temple_construction.g3d"/>
 			<sound enabled="false"/>
-		</skill>	
-			
+		</skill>
+
 
 		<skill>
 			<type value="produce" />
-			<name value="produce_skill"/>		
+			<name value="produce_skill"/>
 			<ep-cost value="0" />
 			<speed value="300" />
 			<anim-speed value="300" />
@@ -87,22 +87,22 @@
 				<particle-file path="smoke_aura.xml"/>
 			</particles>
 			<sound enabled="false" />
-		</skill>	
-		
+		</skill>
+
 		<skill>
 			<type value="die" />
-			<name value="die_skill"/>		
+			<name value="die_skill"/>
 			<ep-cost value="0" />
 			<speed value="300" />
 			<anim-speed value="300" />
 			<animation path="models/sheol_temple_destruction.g3d" />
 			<sound enabled="true" start-time="0">
 				<sound-file path="../enchantment_tower/sounds/dark_magic_building_fall2.wav"/>
-			</sound>			
+			</sound>
 			<fade value="false"/>
 		</skill>
 	</skills>
-	
+
 	<!-- *** commands *** -->
 	<commands>
 		<command>

--- a/dm_test/factions/dark_magic/units/oblivion_portal/oblivion_portal.xml
+++ b/dm_test/factions/dark_magic/units/oblivion_portal/oblivion_portal.xml
@@ -9,7 +9,7 @@
 		<armor-type value="stone"/>
 		<sight value="6" />
 		<time value="100" />
-		<multi-selection value="false" />
+		<multi-selection value="true" />
 		<cellmap value="false"/>
 		<levels/>
 		<fields>
@@ -37,10 +37,10 @@
 		</selection-sounds>
 		<command-sounds enabled="false"/>
 	</parameters>
-	
+
 	<skills>
 		<skill>
-			<type value="stop"/>	
+			<type value="stop"/>
 			<name value="stop_skill"/>
 			<ep-cost value="0" />
 			<speed value="50" />
@@ -48,20 +48,20 @@
 			<animation path="models/portal.g3d" />
 			<sound enabled="false" />
 		</skill>
-		
+
 		<skill>
-			<type value="be_built" />	
-			<name value="be_built_skill"/>		
+			<type value="be_built" />
+			<name value="be_built_skill"/>
 			<ep-cost value="0" />
 			<speed value="300" />
 			<anim-speed value="300" />
 			<animation path="models/portal_construction.g3d" />
 			<sound enabled="false" />
 		</skill>
-		
+
 		<skill>
 			<type value="produce"/>
-			<name value="produce_skill"/>	
+			<name value="produce_skill"/>
 			<ep-cost value="0" />
 			<speed value="300" />
 			<anim-speed value="300" />
@@ -70,22 +70,22 @@
 				<particle-file path="produce_particles.xml"/>
 			</particles>
 			<sound enabled="false" />
-		</skill>	
-		
+		</skill>
+
 		<skill>
-			<type value="die" />	
-			<name value="die_skill"/>		
+			<type value="die" />
+			<name value="die_skill"/>
 			<ep-cost value="0" />
 			<speed value="300" />
 			<anim-speed value="300" />
 			<animation path="models/portal_destruction.g3d" />
 			<sound enabled="true" start-time="0">
 				<sound-file path="../enchantment_tower/sounds/dark_magic_building_fall6.wav"/>
-			</sound>			
+			</sound>
 			<fade value="false"/>
 		</skill>
 	</skills>
-	
+
 	<commands>
 		<command>
 			<type value="produce"/>
@@ -106,7 +106,7 @@
 			<produce-skill value="produce_skill"/>
 			<produced-unit name="dark_elder"/>
 		</command>
-		
+
 		<command>
 			<type value="produce"/>
 			<name value="produce_gargoyle" />

--- a/dm_test/factions/dark_magic/units/sorcery_runes/sorcery_runes.xml
+++ b/dm_test/factions/dark_magic/units/sorcery_runes/sorcery_runes.xml
@@ -6,13 +6,13 @@
 		<max-hp value="6000" regeneration="0"/>
 		<max-ep value="0"/>
 		<armor value="5"/>
-		<armor-type value="stone"/>		
+		<armor-type value="stone"/>
 		<sight value="14" />
 		<time value="110" />
-		<multi-selection value="false"/>
+		<multi-selection value="true"/>
 		<cellmap value="true">
-			<row value="010"/> 
-			<row value="111"/> 
+			<row value="010"/>
+			<row value="111"/>
 			<row value="010"/>
 		</cellmap>
 		<levels/>
@@ -42,10 +42,10 @@
 			<sound path="../enchantment_tower/sounds/dark_magic_click.wav"/>
 		</command-sounds>
 	</parameters>
-	
+
 	<skills>
 		<skill>
-			<name value="be_built_skill"/>		
+			<name value="be_built_skill"/>
 			<ep-cost value="0" />
 			<speed value="300" />
 			<anim-speed value="300" />
@@ -53,20 +53,20 @@
 			<sound enabled="false" />
 			<type value="be_built" />
 		</skill>
-		
+
 		<skill>
 			<type value="stop"/>
-			<name value="stop_skill"/>		
+			<name value="stop_skill"/>
 			<ep-cost value="0"/>
 			<speed value="300"/>
 			<anim-speed value="100" />
 			<animation path="models/sorcery_runes.g3d" />
 			<sound enabled="false" />
-		</skill>	
-		
+		</skill>
+
 		<skill>
 			<type value="upgrade" />
-			<name value="upgrade_skill"/>		
+			<name value="upgrade_skill"/>
 			<ep-cost value="0" />
 			<speed value="300" />
 			<anim-speed value="300" />
@@ -80,7 +80,7 @@
 
 		<skill>
 			<type value="produce" />
-			<name value="produce_skill"/>		
+			<name value="produce_skill"/>
 			<ep-cost value="0" />
 			<speed value="300" />
 			<anim-speed value="300" />
@@ -91,17 +91,17 @@
 			</particles>
 			<sound enabled="false" />
 		</skill>
-		
+
 		<skill>
 			<type value="die" />
-			<name value="die_skill"/>		
+			<name value="die_skill"/>
 			<ep-cost value="0" />
 			<speed value="300" />
 			<anim-speed value="300" />
 			<animation path="models/sorcery_runes_destruction.g3d" />
 			<sound enabled="true" start-time="0">
 				<sound-file path="../enchantment_tower/sounds/dark_magic_building_fall5.wav"/>
-			</sound>			
+			</sound>
 			<fade value="false"/>
 		</skill>
 	</skills>


### PR DESCRIPTION
changes multi-selection value from "false" to "true"
for buildings. MG version 3.13 supports this; doesn't
conflict with 3.12

I edited these files with Geany. Looking at the diff, I see
that Geany auto-removed some trailing whitespace on several
lines of each file.